### PR TITLE
minimal changes to compile a 2.13.x compatible version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ val commonSettings = Seq(
   compileOrder := CompileOrder.JavaThenScala,
   resolvers += Resolver.mavenLocal,
   concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
+  publishTo := Some("ASOC Libs" at "https://sumologicusw1.jfrog.io/sumologicusw1/asoc-release-local/"),
   scalacOptions ++= Seq(
 //    "-deprecation",
     "-encoding", "UTF-8",

--- a/build.sbt
+++ b/build.sbt
@@ -16,20 +16,21 @@
 
 lazy val kamon = (project in file("."))
   .settings(moduleName := "kamon")
-  .settings(noPublishing: _*)
+//  .settings(noPublishing: _*)
   .aggregate(core, testkit, coreTests)
 
 val commonSettings = Seq(
-  scalaVersion := "2.12.4",
+  scalaVersion := "2.13.8",
   javacOptions += "-XDignore.symbol.file",
+  compileOrder := CompileOrder.JavaThenScala,
   resolvers += Resolver.mavenLocal,
-  crossScalaVersions := Seq("2.12.4", "2.11.8", "2.10.6"),
+  crossScalaVersions := Seq("2.13.8"),
   concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
   scalacOptions ++= Seq(
-    "-deprecation",
+//    "-deprecation",
     "-encoding", "UTF-8",
     "-feature",
-    "-Xfuture",
+//    "-Xfuture",
     "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-language:postfixOps",
     "-unchecked"
   ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
@@ -48,7 +49,7 @@ lazy val core = (project in file("kamon-core"))
       "com.typesafe"     %  "config"          % "1.3.1",
       "org.slf4j"        %  "slf4j-api"       % "1.7.25",
       "org.hdrhistogram" %  "HdrHistogram"    % "2.1.9",
-      "com.lihaoyi"      %% "fansi"           % "0.2.4"
+      "com.lihaoyi"      %% "fansi"           % "0.2.14"
     )
   )
 
@@ -57,7 +58,7 @@ lazy val testkit = (project in file("kamon-testkit"))
   .settings(commonSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.1"
+      "org.scalatest" %% "scalatest" % "3.0.9"
     )
   ).dependsOn(core)
 
@@ -67,11 +68,11 @@ lazy val coreTests = (project in file("kamon-core-tests"))
     moduleName := "kamon-core-tests",
     resolvers += Resolver.mavenLocal,
     fork in Test := true)
-  .settings(noPublishing: _*)
+//  .settings(noPublishing: _*)
   .settings(commonSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+      "org.scalatest" %% "scalatest" % "3.0.9" % "test",
       "ch.qos.logback" % "logback-classic" % "1.2.2" % "test"
     )
   ).dependsOn(testkit)

--- a/build.sbt
+++ b/build.sbt
@@ -16,15 +16,15 @@
 
 lazy val kamon = (project in file("."))
   .settings(moduleName := "kamon")
-//  .settings(noPublishing: _*)
   .aggregate(core, testkit, coreTests)
 
+
 val commonSettings = Seq(
+  organization := "io.kamon",
   scalaVersion := "2.13.8",
   javacOptions += "-XDignore.symbol.file",
   compileOrder := CompileOrder.JavaThenScala,
   resolvers += Resolver.mavenLocal,
-  crossScalaVersions := Seq("2.13.8"),
   concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
   scalacOptions ++= Seq(
 //    "-deprecation",
@@ -33,12 +33,7 @@ val commonSettings = Seq(
 //    "-Xfuture",
     "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-language:postfixOps",
     "-unchecked"
-  ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2,10)) => Seq("-Yno-generic-signatures", "-target:jvm-1.7")
-    case Some((2,11)) => Seq("-Ybackend:GenBCode","-Ydelambdafy:method","-target:jvm-1.8")
-    case Some((2,12)) => Seq("-opt:l:method")
-    case _ => Seq.empty
-  })
+  )
 )
 
 lazy val core = (project in file("kamon-core"))

--- a/kamon-core-tests/src/test/scala/kamon/util/EnvironmentTagBuilderSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/util/EnvironmentTagBuilderSpec.scala
@@ -1,0 +1,104 @@
+/* =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon
+package util
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{Matchers, WordSpec}
+
+class EnvironmentTagBuilderSpec extends WordSpec with Matchers {
+  private val testEnv = Environment.fromConfig(ConfigFactory.parseString(
+    """
+      |kamon.environment {
+      |  service = environment-spec
+      |  host = my-hostname
+      |  instance = my-instance-name
+      |
+      |  tags {
+      |    env = staging
+      |    region = asia-1
+      |  }
+      |}
+    """.stripMargin
+  ).withFallback(ConfigFactory.defaultReference()))
+
+  "the EnvironmentTagBuilder" should {
+
+    "build the tags from a configuration using the current Environment" in {
+      val config = ConfigFactory.parseString(
+        """
+          |service = yes
+          |host = yes
+          |instance = yes
+          |blacklisted-tags = []
+        """.stripMargin)
+
+      val env = Kamon.environment
+      val tags = EnvironmentTagBuilder.create(config)
+      tags("service") shouldBe env.service
+      tags("host") shouldBe env.host
+      tags("instance") shouldBe env.instance
+    }
+
+    "build tags from a custom Environment" in {
+      val config = ConfigFactory.parseString(
+        """
+          |service = yes
+          |host = yes
+          |instance = yes
+          |blacklisted-tags = []
+        """.stripMargin)
+
+      val tags = EnvironmentTagBuilder.create(testEnv, config)
+      tags("service") shouldBe testEnv.service
+      tags("host") shouldBe testEnv.host
+      tags("instance") shouldBe testEnv.instance
+      tags("env") shouldBe "staging"
+      tags("region") shouldBe "asia-1"
+
+    }
+
+    "remove blacklisted tags" in {
+      val config = ConfigFactory.parseString(
+        """
+          |service = yes
+          |host = yes
+          |instance = yes
+          |blacklisted-tags = [ "region" ]
+        """.stripMargin)
+
+      val tags = EnvironmentTagBuilder.create(testEnv, config)
+      tags("service") shouldBe testEnv.service
+      tags("host") shouldBe testEnv.host
+      tags("instance") shouldBe testEnv.instance
+      tags("env") shouldBe "staging"
+      tags.get("region") shouldBe empty
+    }
+
+    "remove all disabled elements" in {
+      val config = ConfigFactory.parseString(
+        """
+          |service = no
+          |host = no
+          |instance = no
+          |blacklisted-tags = [ "region", "env" ]
+        """.stripMargin)
+
+      val tags = EnvironmentTagBuilder.create(testEnv, config)
+      tags shouldBe empty
+    }
+  }
+}

--- a/kamon-core/src/main/resources/reference.conf
+++ b/kamon-core/src/main/resources/reference.conf
@@ -197,15 +197,6 @@ kamon {
   util {
     filters {
 
-      # Determines whether entities from a category that doesn't have any filtering configuration should be tracked or
-      # not. E.g. If there are no filter sections for the "jdbc-datasource" category and `accept-unmatched-categories`
-      # is set to true, all entities for that category will be accepted, otherwise all will be rejected.
-      #
-      # NOTE: Using entity fil`ters is a commodity for modules that might potentially track thousands of unnecessary
-      #       entities, but not all modules are required to use filters, check the your module's documentation to
-      #       determine whether setting up filters make sense or not.
-      accept-unmatched = true
-
     }
   }
 }

--- a/kamon-core/src/main/scala/kamon/ReporterRegistry.scala
+++ b/kamon-core/src/main/scala/kamon/ReporterRegistry.scala
@@ -381,7 +381,7 @@ object ReporterRegistry {
 
             Future {
               Try {
-                entry.reporter.reportSpans(spanBatch.asScala)
+                entry.reporter.reportSpans(spanBatch.asScala.toSeq)
               }.failed.foreach { error =>
                 logger.error(s"Reporter [${entry.name}] failed to report spans.", error)
               }
@@ -396,7 +396,7 @@ object ReporterRegistry {
         optimisticMetricTickAlignment = config.getBoolean("kamon.metric.optimistic-tick-alignment"),
         traceTickInterval = config.getDuration("kamon.trace.tick-interval"),
         traceReporterQueueSize = config.getInt("kamon.trace.reporter-queue-size"),
-        configuredReporters = config.getStringList("kamon.reporters").asScala
+        configuredReporters = config.getStringList("kamon.reporters").asScala.toSeq
       )
 
     private case class Configuration(metricTickInterval: Duration, optimisticMetricTickAlignment: Boolean,

--- a/kamon-core/src/main/scala/kamon/package.scala
+++ b/kamon-core/src/main/scala/kamon/package.scala
@@ -67,7 +67,7 @@ package object kamon {
   implicit class AtomicGetOrElseUpdateOnTrieMap[K, V](val trieMap: TrieMap[K, V]) extends AnyVal {
 
     def atomicGetOrElseUpdate(key: K, op: ⇒ V): V =
-      atomicGetOrElseUpdate(key, op, { v: V ⇒ Unit })
+      atomicGetOrElseUpdate(key, op, { v: V ⇒ () })
 
     def atomicGetOrElseUpdate(key: K, op: ⇒ V, cleanup: V ⇒ Unit): V =
       trieMap.get(key) match {

--- a/kamon-core/src/main/scala/kamon/trace/SpanCodec.scala
+++ b/kamon-core/src/main/scala/kamon/trace/SpanCodec.scala
@@ -37,7 +37,9 @@ object SpanCodec {
         val spanContext = span.context()
         carrier.put(Headers.TraceIdentifier, urlEncode(spanContext.traceID.string))
         carrier.put(Headers.SpanIdentifier, urlEncode(spanContext.spanID.string))
-        carrier.put(Headers.ParentSpanIdentifier, urlEncode(spanContext.parentID.string))
+
+        if(spanContext.parentID != IdentityProvider.NoIdentifier)
+          carrier.put(Headers.ParentSpanIdentifier, urlEncode(spanContext.parentID.string))
 
         encodeSamplingDecision(spanContext.samplingDecision).foreach { samplingDecision =>
           carrier.put(Headers.Sampled, samplingDecision)

--- a/kamon-core/src/main/scala/kamon/util/EnvironmentTagBuilder.scala
+++ b/kamon-core/src/main/scala/kamon/util/EnvironmentTagBuilder.scala
@@ -1,0 +1,43 @@
+package kamon.util
+
+import com.typesafe.config.Config
+import kamon.{Environment, Kamon}
+
+import scala.collection.JavaConverters._
+
+
+/**
+  *   Utility class to create a Map[String, String] encoding all the Environment information based on the provided
+  *   Config. The Config instance is expected to have the following members:
+  *
+  *     - service:          Boolean. If true a service tag is included.
+  *     - host:             Boolean. If true a host tag is included.
+  *     - instance:         Boolean. If true a instance tag is included.
+  *     - blacklisted-tags: List[String]. List of Environment tags that should not be included in the result.
+  *
+  *   This utility is meant to be used mostly by reporter modules.
+  *
+  */
+object EnvironmentTagBuilder {
+
+  def create(config: Config): Map[String, String] =
+    create(Kamon.environment, config)
+
+  def create(env: Environment, config: Config): Map[String, String] = {
+    val envTags = Map.newBuilder[String, String]
+
+    if(config.getBoolean("service"))
+      envTags += ("service" -> env.service)
+
+    if(config.getBoolean("host"))
+      envTags += ("host" -> env.host)
+
+    if(config.getBoolean("instance"))
+      envTags += ("instance" -> env.instance)
+
+    val blacklistedTags = config.getStringList("blacklisted-tags").asScala
+    env.tags.filterKeys(k => !blacklistedTags.contains(k)).foreach(p => envTags += p)
+
+    envTags.result()
+  }
+}

--- a/kamon-core/src/main/scala/kamon/util/Filters.scala
+++ b/kamon-core/src/main/scala/kamon/util/Filters.scala
@@ -39,7 +39,7 @@ object Filters {
     val configKey = ConfigUtil.joinPath(name, key)
 
     if(filtersConfig.hasPath(configKey))
-      filtersConfig.getStringList(configKey).asScala.map(readMatcher)
+      filtersConfig.getStringList(configKey).asScala.toSeq.map(readMatcher)
     else
       Seq.empty
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 resolvers += Resolver.bintrayIvyRepo("kamon-io", "sbt-plugins")
-addSbtPlugin("io.kamon" % "kamon-sbt-umbrella" % "0.0.15")
+//addSbtPlugin("io.kamon" % "kamon-sbt-umbrella" % "0.0.15")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.1"
+version in ThisBuild := "1.1.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.1-SNAPSHOT"
+version in ThisBuild := "1.1.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.2-SNAPSHOT"
+version in ThisBuild := "1.1.2"


### PR DESCRIPTION
note - this requires java8 to build locally due to sun.misc.unsafe usage (unchanged in later kamon)

- intention is to publish this to sumo repos
- this PR is really just illustrative, latest 1.1. maintenance is 1.1.6, since we're on 1.1.2 everywhere this targets only including what is in 1.1.2 but published for 2.13
- `Kamon 2.*` (the first version stably cross-compiled for Scala 2.13) has significant changes, whereas the changes to compile 1.1.x are actually minimal
- official 2.12 artifacts exist, so no attempt was made at preserving 2.12 here: all we want is a published artifact
- we should update kamon... but that work is much larger in scope than resolving the lack of a 2.13 version of `kamon-core`